### PR TITLE
fix: retry on version curl

### DIFF
--- a/dist/codecov.sh
+++ b/dist/codecov.sh
@@ -37,6 +37,7 @@ b="\033[0;36m"  # variables/constants
 g="\033[0;32m"  # info/debug
 r="\033[0;31m"  # errors
 x="\033[0m"
+retry="--retry 5 --retry-delay 2"
 say "     _____          _
     / ____|        | |
    | |     ___   __| | ___  ___ _____   __
@@ -89,11 +90,11 @@ else
   c_url="$c_url/${CC_VERSION}"
   c_url="$c_url/${CC_OS}/${c_filename}"
   say "$g ->$x Downloading $b${c_url}$x"
-  curl -O --retry 5 --retry-delay 2 "$c_url"
+  curl -O $retry "$c_url"
   say "$g==>$x Finishing downloading $b${CC_OS}:${CC_VERSION}$x"
-  version_url="https://cli.codecov.io/api/${CC_OS}/${CC_VERSION}"
-  version=$(curl -s "$version_url" -H "Accept:application/json" | tr \{ '\n' | tr , '\n' | tr \} '\n' | grep "\"version\"" | awk  -F'"' '{print $4}' | tail -1)
-  say "      Version: $b$version$x"
+  v_url="https://cli.codecov.io/api/${CC_OS}/${CC_VERSION}"
+  v=$(curl $retry --retry-all-errors -s "$v_url" -H "Accept:application/json" | tr \{ '\n' | tr , '\n' | tr \} '\n' | grep "\"version\"" | awk  -F'"' '{print $4}' | tail -1)
+  say "      Version: $b$v$x"
   say " "
 fi
 if [ "$CC_SKIP_VALIDATION" == "true" ] || [ -n "$CC_BINARY" ] || [ "$CC_USE_PYPI" == "true" ];
@@ -111,8 +112,8 @@ CC_PUBLIC_PGP_KEY=$(curl -s https://keybase.io/codecovsecurity/pgp_keys.asc)
   say "$g ->$x Downloading $b${sha_url}$x"
   say "$g ->$x Downloading $b${sha_url}.sig$x"
   say " "
-  curl -Os --retry 5 --retry-delay 2 --connect-timeout 2 "$sha_url"
-  curl -Os --retry 5 --retry-delay 2 --connect-timeout 2 "${sha_url}.sig"
+  curl -Os $retry --connect-timeout 2 "$sha_url"
+  curl -Os $retry --connect-timeout 2 "${sha_url}.sig"
   if ! gpg --verify "${c_filename}.SHA256SUM.sig" "${c_filename}.SHA256SUM";
   then
     exit_if_error "Could not verify signature. Please contact Codecov if problem continues"

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -42,11 +42,11 @@ else
   codecov_url="$codecov_url/${CODECOV_VERSION}"
   codecov_url="$codecov_url/${CODECOV_OS}/${codecov_filename}"
   say "$g ->$x Downloading $b${codecov_url}$x"
-  curl -O --retry 5 --retry-delay 2 "$codecov_url"
+  curl -O $retry "$codecov_url"
   say "$g==>$x Finishing downloading $b${CODECOV_OS}:${CODECOV_VERSION}$x"
 
-  version_url="https://cli.codecov.io/api/${CODECOV_OS}/${CODECOV_VERSION}"
-  version=$(curl -s "$version_url" -H "Accept:application/json" | tr \{ '\n' | tr , '\n' | tr \} '\n' | grep "\"version\"" | awk  -F'"' '{print $4}' | tail -1)
-  say "      Version: $b$version$x"
+  v_url="https://cli.codecov.io/api/${CODECOV_OS}/${CODECOV_VERSION}"
+  v=$(curl $retry --retry-all-errors -s "$v_url" -H "Accept:application/json" | tr \{ '\n' | tr , '\n' | tr \} '\n' | grep "\"version\"" | awk  -F'"' '{print $4}' | tail -1)
+  say "      Version: $b$v$x"
   say " "
 fi

--- a/scripts/set_defaults.sh
+++ b/scripts/set_defaults.sh
@@ -43,6 +43,7 @@ b="\033[0;36m"  # variables/constants
 g="\033[0;32m"  # info/debug
 r="\033[0;31m"  # errors
 x="\033[0m"
+retry="--retry 5 --retry-delay 2"
 
 say "     _____          _
     / ____|        | |

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -16,8 +16,8 @@ else
   say "$g ->$x Downloading $b${sha_url}.sig$x"
   say " "
 
-  curl -Os --retry 5 --retry-delay 2 --connect-timeout 2 "$sha_url"
-  curl -Os --retry 5 --retry-delay 2 --connect-timeout 2 "${sha_url}.sig"
+  curl -Os $retry --connect-timeout 2 "$sha_url"
+  curl -Os $retry --connect-timeout 2 "${sha_url}.sig"
 
   if ! gpg --verify "${codecov_filename}.SHA256SUM.sig" "${codecov_filename}.SHA256SUM";
   then


### PR DESCRIPTION
we do retry-all-errors as an attempt to catch exit code 56 errors