### PR TITLE
fix: download CLI to temp dir and retry GPG key import

### DIFF
--- a/dist/codecov.sh
+++ b/dist/codecov.sh
@@ -71,6 +71,11 @@ then
   fi
   CC_COMMAND="${CC_CLI_TYPE}"
 else
+  CC_DOWNLOAD_DIR=$(mktemp -d)
+  cleanup_downloads() {
+    rm -rf "$CC_DOWNLOAD_DIR"
+  }
+  trap cleanup_downloads EXIT
   if [ -n "$CC_OS" ];
   then
     say "$g==>$x Overridden OS: $b${CC_OS}$x"
@@ -87,7 +92,7 @@ else
   fi
   CC_FILENAME="${CC_CLI_TYPE%-cli}"
   [[ $CC_OS == "windows" ]] && CC_FILENAME+=".exe"
-  CC_COMMAND="./$CC_FILENAME"
+  CC_COMMAND="$CC_DOWNLOAD_DIR/$CC_FILENAME"
   [[ $CC_OS == "macos" ]]  && \
     ! command -v gpg 2>&1 >/dev/null && \
     HOMEBREW_NO_AUTO_UPDATE=1 brew install gpg
@@ -95,7 +100,7 @@ else
   CC_URL="$CC_URL/${CC_VERSION}"
   CC_URL="$CC_URL/${CC_OS}/${CC_FILENAME}"
   say "$g ->$x Downloading $b${CC_URL}$x"
-  curl -O $retry "$CC_URL"
+  curl -o "$CC_DOWNLOAD_DIR/$CC_FILENAME" $retry "$CC_URL"
   say "$g==>$x Finishing downloading $b${CC_OS}:${CC_VERSION}$x"
   v_url="https://cli.codecov.io/api/${CC_OS}/${CC_VERSION}"
   v=$(curl $retry --retry-all-errors -s "$v_url" -H "Accept:application/json" | tr \{ '\n' | tr , '\n' | tr \} '\n' | grep "\"version\"" | awk  -F'"' '{print $4}' | tail -1)
@@ -110,9 +115,19 @@ then
     chmod +x "$CC_COMMAND"
   fi
 else
-  echo "$(curl -s https://keybase.io/codecovsecurity/pgp_keys.asc)" | \
-    gpg --no-default-keyring --import
-  # One-time step
+  gpg_key_url="https://keybase.io/codecovsecurity/pgp_keys.asc"
+  gpg_import_ok=false
+  for gpg_attempt in 1 2 3; do
+    if curl -sf $retry "$gpg_key_url" | gpg --no-default-keyring --import 2>/dev/null; then
+      gpg_import_ok=true
+      break
+    fi
+    say "$r ->$x GPG key import attempt $gpg_attempt failed, retrying..."
+    sleep 2
+  done
+  if [ "$gpg_import_ok" != "true" ]; then
+    exit_if_error "Could not import GPG verification key after 3 attempts. Please contact Codecov if problem continues"
+  fi
   say "$g==>$x Verifying GPG signature integrity"
   sha_url="https://cli.codecov.io"
   sha_url="${sha_url}/${CC_VERSION}/${CC_OS}"
@@ -120,14 +135,14 @@ else
   say "$g ->$x Downloading $b${sha_url}$x"
   say "$g ->$x Downloading $b${sha_url}.sig$x"
   say " "
-  curl -Os $retry --connect-timeout 2 "$sha_url"
-  curl -Os $retry --connect-timeout 2 "${sha_url}.sig"
-  if ! gpg --verify "${CC_FILENAME}.SHA256SUM.sig" "${CC_FILENAME}.SHA256SUM";
+  curl -o "$CC_DOWNLOAD_DIR/${CC_FILENAME}.SHA256SUM" -s $retry --connect-timeout 2 "$sha_url"
+  curl -o "$CC_DOWNLOAD_DIR/${CC_FILENAME}.SHA256SUM.sig" -s $retry --connect-timeout 2 "${sha_url}.sig"
+  if ! gpg --verify "$CC_DOWNLOAD_DIR/${CC_FILENAME}.SHA256SUM.sig" "$CC_DOWNLOAD_DIR/${CC_FILENAME}.SHA256SUM";
   then
     exit_if_error "Could not verify signature. Please contact Codecov if problem continues"
   fi
-  if ! (shasum -a 256 -c "${CC_FILENAME}.SHA256SUM" 2>/dev/null || \
-    sha256sum -c "${CC_FILENAME}.SHA256SUM");
+  if ! (cd "$CC_DOWNLOAD_DIR" && (shasum -a 256 -c "${CC_FILENAME}.SHA256SUM" 2>/dev/null || \
+    sha256sum -c "${CC_FILENAME}.SHA256SUM"));
   then
     exit_if_error "Could not verify SHASUM. Please contact Codecov if problem continues"
   fi
@@ -137,11 +152,16 @@ else
 fi
 if [ -n "$CC_BINARY_LOCATION" ];
 then
-  mkdir -p "$CC_BINARY_LOCATION" && mv "$CC_FILENAME" $_
+  mkdir -p "$CC_BINARY_LOCATION" && mv "$CC_COMMAND" "$CC_BINARY_LOCATION/$CC_FILENAME"
+  CC_COMMAND="$CC_BINARY_LOCATION/$CC_FILENAME"
   say "$g==>$x ${CC_CLI_TYPE} binary moved to ${CC_BINARY_LOCATION}"
 fi
 if [ "$CC_DOWNLOAD_ONLY" = "true" ];
 then
+  if [ -n "$CC_DOWNLOAD_DIR" ] && [ -z "$CC_BINARY_LOCATION" ]; then
+    cp "$CC_COMMAND" "./$CC_FILENAME"
+    CC_COMMAND="./$CC_FILENAME"
+  fi
   say "$g==>$x ${CC_CLI_TYPE} download only called. Exiting..."
   exit
 fi

--- a/dist/codecov.sh
+++ b/dist/codecov.sh
@@ -42,6 +42,7 @@ CC_VERSION="${CC_VERSION:-latest}"
 CC_FAIL_ON_ERROR="${CC_FAIL_ON_ERROR:-false}"
 CC_RUN_CMD="${CC_RUN_CMD:-upload-coverage}"
 CC_CLI_TYPE=${CC_CLI_TYPE:-"codecov-cli"}
+CC_CLEANUP="${CC_CLEANUP:-false}"
 say "     _____          _
     / ____|        | |
    | |     ___   __| | ___  ___ _____   __
@@ -77,6 +78,14 @@ then
     CC_COMMAND="${CC_CLI_TYPE}"
   fi
 else
+  CC_DOWNLOAD_DIR="."
+  if [ "$CC_CLEANUP" == "true" ]; then
+    CC_DOWNLOAD_DIR=$(mktemp -d)
+    cleanup_downloads() {
+      rm -rf "$CC_DOWNLOAD_DIR"
+    }
+    trap cleanup_downloads EXIT
+  fi
   if [ -n "$CC_OS" ];
   then
     say "$g==>$x Overridden OS: $b${CC_OS}$x"
@@ -93,7 +102,7 @@ else
   fi
   CC_FILENAME="${CC_CLI_TYPE%-cli}"
   [[ $CC_OS == "windows" ]] && CC_FILENAME+=".exe"
-  CC_COMMAND="./$CC_FILENAME"
+  CC_COMMAND="$CC_DOWNLOAD_DIR/$CC_FILENAME"
   [[ $CC_OS == "macos" ]]  && \
     ! command -v gpg 2>&1 >/dev/null && \
     HOMEBREW_NO_AUTO_UPDATE=1 brew install gpg
@@ -101,7 +110,7 @@ else
   CC_URL="$CC_URL/${CC_VERSION}"
   CC_URL="$CC_URL/${CC_OS}/${CC_FILENAME}"
   say "$g ->$x Downloading $b${CC_URL}$x"
-  curl -O $retry "$CC_URL"
+  curl -o "$CC_COMMAND" $retry "$CC_URL"
   say "$g==>$x Finishing downloading $b${CC_OS}:${CC_VERSION}$x"
   v_url="https://cli.codecov.io/api/${CC_OS}/${CC_VERSION}"
   v=$(curl $retry --retry-all-errors -s "$v_url" -H "Accept:application/json" | tr \{ '\n' | tr , '\n' | tr \} '\n' | grep "\"version\"" | awk  -F'"' '{print $4}' | tail -1)
@@ -116,9 +125,21 @@ then
     chmod +x "$CC_COMMAND"
   fi
 else
-  echo "$(curl -s https://keybase.io/codecovsecops/pgp_keys.asc)" | \
-    gpg --no-default-keyring --import
-  # One-time step
+  gpg_key_url="https://keybase.io/codecovsecops/pgp_keys.asc"
+  gpg_import_ok=false
+  for gpg_attempt in 1 2 3; do
+    if curl -sf $retry "$gpg_key_url" | gpg --no-default-keyring --import; then
+      gpg_import_ok=true
+      break
+    fi
+    if [ "$gpg_attempt" -lt 3 ]; then
+      say "$r ->$x GPG key import attempt $gpg_attempt failed, retrying..."
+      sleep 2
+    fi
+  done
+  if [ "$gpg_import_ok" != "true" ]; then
+    exit_if_error "Could not import GPG verification key after 3 attempts. Please contact Codecov if problem continues"
+  fi
   say "$g==>$x Verifying GPG signature integrity"
   sha_url="https://cli.codecov.io"
   sha_url="${sha_url}/${CC_VERSION}/${CC_OS}"
@@ -126,14 +147,14 @@ else
   say "$g ->$x Downloading $b${sha_url}$x"
   say "$g ->$x Downloading $b${sha_url}.sig$x"
   say " "
-  curl -Os $retry --connect-timeout 2 "$sha_url"
-  curl -Os $retry --connect-timeout 2 "${sha_url}.sig"
-  if ! gpg --verify "${CC_FILENAME}.SHA256SUM.sig" "${CC_FILENAME}.SHA256SUM";
+  curl -o "$CC_DOWNLOAD_DIR/${CC_FILENAME}.SHA256SUM" -s $retry --connect-timeout 2 "$sha_url"
+  curl -o "$CC_DOWNLOAD_DIR/${CC_FILENAME}.SHA256SUM.sig" -s $retry --connect-timeout 2 "${sha_url}.sig"
+  if ! gpg --verify "$CC_DOWNLOAD_DIR/${CC_FILENAME}.SHA256SUM.sig" "$CC_DOWNLOAD_DIR/${CC_FILENAME}.SHA256SUM";
   then
     exit_if_error "Could not verify signature. Please contact Codecov if problem continues"
   fi
-  if ! (shasum -a 256 -c "${CC_FILENAME}.SHA256SUM" 2>/dev/null || \
-    sha256sum -c "${CC_FILENAME}.SHA256SUM");
+  if ! (cd "$CC_DOWNLOAD_DIR" && (shasum -a 256 -c "${CC_FILENAME}.SHA256SUM" 2>/dev/null || \
+    sha256sum -c "${CC_FILENAME}.SHA256SUM"));
   then
     exit_if_error "Could not verify SHASUM. Please contact Codecov if problem continues"
   fi
@@ -143,11 +164,16 @@ else
 fi
 if [ -n "$CC_BINARY_LOCATION" ];
 then
-  mkdir -p "$CC_BINARY_LOCATION" && mv "$CC_FILENAME" $_
+  mkdir -p "$CC_BINARY_LOCATION" && mv "$CC_COMMAND" "$CC_BINARY_LOCATION/$CC_FILENAME"
+  CC_COMMAND="$CC_BINARY_LOCATION/$CC_FILENAME"
   say "$g==>$x ${CC_CLI_TYPE} binary moved to ${CC_BINARY_LOCATION}"
 fi
 if [ "$CC_DOWNLOAD_ONLY" = "true" ];
 then
+  if [ "$CC_CLEANUP" == "true" ] && [ -z "$CC_BINARY_LOCATION" ]; then
+    cp "$CC_COMMAND" "./$CC_FILENAME"
+    CC_COMMAND="./$CC_FILENAME"
+  fi
   say "$g==>$x ${CC_CLI_TYPE} download only called. Exiting..."
   exit
 fi

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -23,6 +23,15 @@ then
     CODECOV_COMMAND="${CODECOV_CLI_TYPE}"
   fi
 else
+  CODECOV_DOWNLOAD_DIR="."
+  if [ "$CODECOV_CLEANUP" == "true" ]; then
+    CODECOV_DOWNLOAD_DIR=$(mktemp -d)
+    cleanup_downloads() {
+      rm -rf "$CODECOV_DOWNLOAD_DIR"
+    }
+    trap cleanup_downloads EXIT
+  fi
+
   if [ -n "$CODECOV_OS" ];
   then
     say "$g==>$x Overridden OS: $b${CODECOV_OS}$x"
@@ -40,7 +49,7 @@ else
 
   CODECOV_FILENAME="${CODECOV_CLI_TYPE%-cli}"
   [[ $CODECOV_OS == "windows" ]] && CODECOV_FILENAME+=".exe"
-  CODECOV_COMMAND="./$CODECOV_FILENAME"
+  CODECOV_COMMAND="$CODECOV_DOWNLOAD_DIR/$CODECOV_FILENAME"
   [[ $CODECOV_OS == "macos" ]]  && \
     ! command -v gpg 2>&1 >/dev/null && \
     HOMEBREW_NO_AUTO_UPDATE=1 brew install gpg
@@ -48,7 +57,7 @@ else
   CODECOV_URL="$CODECOV_URL/${CODECOV_VERSION}"
   CODECOV_URL="$CODECOV_URL/${CODECOV_OS}/${CODECOV_FILENAME}"
   say "$g ->$x Downloading $b${CODECOV_URL}$x"
-  curl -O $retry "$CODECOV_URL"
+  curl -o "$CODECOV_COMMAND" $retry "$CODECOV_URL"
   say "$g==>$x Finishing downloading $b${CODECOV_OS}:${CODECOV_VERSION}$x"
 
   v_url="https://cli.codecov.io/api/${CODECOV_OS}/${CODECOV_VERSION}"

--- a/scripts/set_defaults.sh
+++ b/scripts/set_defaults.sh
@@ -5,6 +5,7 @@ CODECOV_VERSION="${CODECOV_VERSION:-latest}"
 CODECOV_FAIL_ON_ERROR="${CODECOV_FAIL_ON_ERROR:-false}"
 CODECOV_RUN_CMD="${CODECOV_RUN_CMD:-upload-coverage}"
 CODECOV_CLI_TYPE=${CODECOV_CLI_TYPE:-"codecov-cli"}
+CODECOV_CLEANUP="${CODECOV_CLEANUP:-false}"
 
 say "     _____          _
     / ____|        | |

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -8,9 +8,22 @@ then
     chmod +x "$CODECOV_COMMAND"
   fi
 else
-  echo "$(curl -s https://keybase.io/codecovsecops/pgp_keys.asc)" | \
-    gpg --no-default-keyring --import
-  # One-time step
+  gpg_key_url="https://keybase.io/codecovsecops/pgp_keys.asc"
+  gpg_import_ok=false
+  for gpg_attempt in 1 2 3; do
+    if curl -sf $retry "$gpg_key_url" | gpg --no-default-keyring --import; then
+      gpg_import_ok=true
+      break
+    fi
+    if [ "$gpg_attempt" -lt 3 ]; then
+      say "$r ->$x GPG key import attempt $gpg_attempt failed, retrying..."
+      sleep 2
+    fi
+  done
+  if [ "$gpg_import_ok" != "true" ]; then
+    exit_if_error "Could not import GPG verification key after 3 attempts. Please contact Codecov if problem continues"
+  fi
+
   say "$g==>$x Verifying GPG signature integrity"
   sha_url="https://cli.codecov.io"
   sha_url="${sha_url}/${CODECOV_VERSION}/${CODECOV_OS}"
@@ -19,16 +32,16 @@ else
   say "$g ->$x Downloading $b${sha_url}.sig$x"
   say " "
 
-  curl -Os $retry --connect-timeout 2 "$sha_url"
-  curl -Os $retry --connect-timeout 2 "${sha_url}.sig"
+  curl -o "$CODECOV_DOWNLOAD_DIR/${CODECOV_FILENAME}.SHA256SUM" -s $retry --connect-timeout 2 "$sha_url"
+  curl -o "$CODECOV_DOWNLOAD_DIR/${CODECOV_FILENAME}.SHA256SUM.sig" -s $retry --connect-timeout 2 "${sha_url}.sig"
 
-  if ! gpg --verify "${CODECOV_FILENAME}.SHA256SUM.sig" "${CODECOV_FILENAME}.SHA256SUM";
+  if ! gpg --verify "$CODECOV_DOWNLOAD_DIR/${CODECOV_FILENAME}.SHA256SUM.sig" "$CODECOV_DOWNLOAD_DIR/${CODECOV_FILENAME}.SHA256SUM";
   then
     exit_if_error "Could not verify signature. Please contact Codecov if problem continues"
   fi
 
-  if ! (shasum -a 256 -c "${CODECOV_FILENAME}.SHA256SUM" 2>/dev/null || \
-    sha256sum -c "${CODECOV_FILENAME}.SHA256SUM");
+  if ! (cd "$CODECOV_DOWNLOAD_DIR" && (shasum -a 256 -c "${CODECOV_FILENAME}.SHA256SUM" 2>/dev/null || \
+    sha256sum -c "${CODECOV_FILENAME}.SHA256SUM"));
   then
     exit_if_error "Could not verify SHASUM. Please contact Codecov if problem continues"
   fi
@@ -39,12 +52,17 @@ fi
 
 if [ -n "$CODECOV_BINARY_LOCATION" ];
 then
-  mkdir -p "$CODECOV_BINARY_LOCATION" && mv "$CODECOV_FILENAME" $_
+  mkdir -p "$CODECOV_BINARY_LOCATION" && mv "$CODECOV_COMMAND" "$CODECOV_BINARY_LOCATION/$CODECOV_FILENAME"
+  CODECOV_COMMAND="$CODECOV_BINARY_LOCATION/$CODECOV_FILENAME"
   say "$g==>$x ${CODECOV_CLI_TYPE} binary moved to ${CODECOV_BINARY_LOCATION}"
 fi
 
 if [ "$CODECOV_DOWNLOAD_ONLY" = "true" ];
 then
+  if [ "$CODECOV_CLEANUP" == "true" ] && [ -z "$CODECOV_BINARY_LOCATION" ]; then
+    cp "$CODECOV_COMMAND" "./$CODECOV_FILENAME"
+    CODECOV_COMMAND="./$CODECOV_FILENAME"
+  fi
   say "$g==>$x ${CODECOV_CLI_TYPE} download only called. Exiting..."
   exit
 fi


### PR DESCRIPTION
## Summary

- Add an opt-in `cleanup` setting (`CC_CLEANUP` in the packaged wrapper), defaulting to `false`
- When enabled, download and verify CLI artifacts in a temporary directory and remove them on exit
- Preserve downloaded binaries for `download_only` and `binary_location` workflows
- Retry Codecov GPG key imports up to three times with explicit failure reporting
- Keep all implementation changes in `scripts/`; `dist/` remains generated and unchanged

## Test plan

- [x] Validate all source scripts with `bash -n scripts/*.sh`
- [x] Run `python -m pytest`
- [x] Verify the PR diff contains only source files under `scripts/`
- [x] Generate and publish `dist/codecov.sh` through the normal release tooling