### PR TITLE
fix: accept true and 1 for skip validation

### DIFF
--- a/dist/codecov.sh
+++ b/dist/codecov.sh
@@ -32,6 +32,14 @@ write_bool_args() {
     echo "-$(lower $1)"
   fi
 }
+parse_bool() {
+  if [ "$1" == "true" ] || [ "$1" == "1" ];
+  then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
 b="\033[0;36m"  # variables/constants
 g="\033[0;32m"  # info/debug
 r="\033[0;31m"  # errors
@@ -102,10 +110,12 @@ else
   say "      Version: $b$v$x"
   say " "
 fi
-if [ "$CC_SKIP_VALIDATION" == "true" ] || [ -n "$CC_BINARY" ] || [ "$CC_USE_PYPI" == "true" ];
+skip_validation="$(parse_bool "$CC_SKIP_VALIDATION")"
+use_pypi="$(parse_bool "$CC_USE_PYPI")"
+if [ "$skip_validation" == "true" ] || [ -n "$CC_BINARY" ] || [ "$use_pypi" == "true" ];
 then
   say "$r==>$x Bypassing validation..."
-  if [ "$CC_SKIP_VALIDATION" == "true" ];
+  if [ "$skip_validation" == "true" ];
   then
     chmod +x "$CC_COMMAND"
   fi

--- a/scripts/set_funcs.sh
+++ b/scripts/set_funcs.sh
@@ -39,6 +39,15 @@ write_bool_args() {
   fi
 }
 
+parse_bool() {
+  if [ "$1" == "true" ] || [ "$1" == "1" ];
+  then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
 b="\033[0;36m"  # variables/constants
 g="\033[0;32m"  # info/debug
 r="\033[0;31m"  # errors

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-if [ "$CODECOV_SKIP_VALIDATION" == "true" ] || [ -n "$CODECOV_BINARY" ] || [ "$CODECOV_USE_PYPI" == "true" ];
+skip_validation="$(parse_bool "$CODECOV_SKIP_VALIDATION")"
+use_pypi="$(parse_bool "$CODECOV_USE_PYPI")"
+
+if [ "$skip_validation" == "true" ] || [ -n "$CODECOV_BINARY" ] || [ "$use_pypi" == "true" ];
 then
   say "$r==>$x Bypassing validation..."
-  if [ "$CODECOV_SKIP_VALIDATION" == "true" ];
+  if [ "$skip_validation" == "true" ];
   then
     chmod +x "$CODECOV_COMMAND"
   fi


### PR DESCRIPTION
CircleCI can pass boolean orb parameters as `1`/`0`, but `validate.sh` only accepted the literal string `true` for `skip_validation`.

This change normalizes the boolean values used in `validate.sh` so `skip_validation` correctly bypasses validation when CircleCI passes `1`.

**Related:** [codecov/codecov-circleci-orb#250](https://github.com/codecov/codecov-circleci-orb/issues/250)