### PR TITLE
fix: accept CircleCI 1/0 for skip_validation and use_pypi

### DIFF
--- a/dist/codecov.sh
+++ b/dist/codecov.sh
@@ -64,7 +64,7 @@ then
   else
     exit_if_error "Could not find binary file $CC_BINARY"
   fi
-elif [ "$CC_USE_PYPI" == "true" ];
+elif [ "$CC_USE_PYPI" == "true" ] || [ "$CC_USE_PYPI" == "1" ];
 then
   if ! pip install "${CC_CLI_TYPE}$([ "$CC_VERSION" == "latest" ] && echo "" || echo "==$CC_VERSION")"; then
     exit_if_error "Could not install via pypi."
@@ -117,10 +117,10 @@ else
   say "      Version: $b$v$x"
   say " "
 fi
-if [ "$CC_SKIP_VALIDATION" == "true" ] || [ -n "$CC_BINARY" ] || [ "$CC_USE_PYPI" == "true" ];
+if [ "$CC_SKIP_VALIDATION" == "true" ] || [ "$CC_SKIP_VALIDATION" == "1" ] || [ -n "$CC_BINARY" ] || [ "$CC_USE_PYPI" == "true" ] || [ "$CC_USE_PYPI" == "1" ];
 then
   say "$r==>$x Bypassing validation..."
-  if [ "$CC_SKIP_VALIDATION" == "true" ];
+  if [ "$CC_SKIP_VALIDATION" == "true" ] || [ "$CC_SKIP_VALIDATION" == "1" ];
   then
     chmod +x "$CC_COMMAND"
   fi

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -9,7 +9,7 @@ then
   else
     exit_if_error "Could not find binary file $CODECOV_BINARY"
   fi
-elif [ "$CODECOV_USE_PYPI" == "true" ];
+elif [ "$CODECOV_USE_PYPI" == "true" ] || [ "$CODECOV_USE_PYPI" == "1" ];
 then
   if ! pip install "${CODECOV_CLI_TYPE}$([ "$CODECOV_VERSION" == "latest" ] && echo "" || echo "==$CODECOV_VERSION")"; then
     exit_if_error "Could not install via pypi."

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-if [ "$CODECOV_SKIP_VALIDATION" == "true" ] || [ -n "$CODECOV_BINARY" ] || [ "$CODECOV_USE_PYPI" == "true" ];
+if [ "$CODECOV_SKIP_VALIDATION" == "true" ] || [ "$CODECOV_SKIP_VALIDATION" == "1" ] || [ -n "$CODECOV_BINARY" ] || [ "$CODECOV_USE_PYPI" == "true" ] || [ "$CODECOV_USE_PYPI" == "1" ];
 then
   say "$r==>$x Bypassing validation..."
-  if [ "$CODECOV_SKIP_VALIDATION" == "true" ];
+  if [ "$CODECOV_SKIP_VALIDATION" == "true" ] || [ "$CODECOV_SKIP_VALIDATION" == "1" ];
   then
     chmod +x "$CODECOV_COMMAND"
   fi


### PR DESCRIPTION
## Summary

- Accept `"1"` as well as `"true"` for `skip_validation` and `use_pypi`, matching the existing `write_bool_args` convention
- Fixes CircleCI orb boolean params being passed as `1`/`0` ([codecov/codecov-circleci-orb#250](https://github.com/codecov/codecov-circleci-orb/issues/250))
- Supersedes #72 without introducing a separate `parse_bool` helper

## Test plan

- [ ] `CODECOV_SKIP_VALIDATION=true` still bypasses validation
- [ ] `CODECOV_SKIP_VALIDATION=1` bypasses validation (CircleCI path)
- [ ] `CODECOV_SKIP_VALIDATION=0` / unset still runs validation
- [ ] `CODECOV_USE_PYPI=1` takes the PyPI install path

Made with [Cursor](https://cursor.com)